### PR TITLE
Make height and width respect all the interface

### DIFF
--- a/bs-css/src/Css_AtomicTypes.res
+++ b/bs-css/src/Css_AtomicTypes.res
@@ -1615,18 +1615,18 @@ module TextDecorationThickness = {
 }
 
 module Width = {
-  type t = [#auto | #fitContent | #maxContent | #minContent]
+  type t = [#auto | #fitContent(Length.t) | #maxContent | #minContent]
 
   let toString = x =>
     switch x {
     | #auto => "auto"
-    | #fitContent => "fit-content"
+    | #fitContent(l) => "fit-content(" ++ Length.toString(l) ++ ")"
     | #maxContent => "max-content"
     | #minContent => "min-content"
     }
 }
 
-module MaxWidth = {
+module None = {
   type t = [#none]
 
   let toString = x =>
@@ -1635,23 +1635,27 @@ module MaxWidth = {
     }
 }
 
+/* min-width and max-width can be set to 'none' and all Width values.
+ Here we only define are the 'none' since the external API ensures the composability of all cases */
+module MinWidth = None
+module MaxWidth = None
+
 module Height = {
-  type t = [#auto]
+  type t = [#auto | #fitContent(Length.t) | #maxContent | #minContent]
 
   let toString = x =>
     switch x {
     | #auto => "auto"
+    | #fitContent(l) => "fit-content(" ++ Length.toString(l) ++ ")"
+    | #maxContent => "max-content"
+    | #minContent => "min-content"
     }
 }
 
-module MaxHeight = {
-  type t = [#none]
-
-  let toString = x =>
-    switch x {
-    | #none => "none"
-    }
-}
+/* min-height and max-height can be set to 'none' and all Height values.
+ Here we only define are the 'none' since the external API ensures the composability of all cases */
+module MaxHeight = None
+module MinHeight = None
 
 module OverflowWrap = {
   type t = [#normal | #breakWord | #anywhere]

--- a/bs-css/src/Css_AtomicTypes.res
+++ b/bs-css/src/Css_AtomicTypes.res
@@ -1615,12 +1615,12 @@ module TextDecorationThickness = {
 }
 
 module Width = {
-  type t = [#auto | #fitContent(Length.t) | #maxContent | #minContent]
+  type t = [#auto | #fitContent | #maxContent | #minContent]
 
   let toString = x =>
     switch x {
     | #auto => "auto"
-    | #fitContent(l) => "fit-content(" ++ Length.toString(l) ++ ")"
+    | #fitContent => "fit-content"
     | #maxContent => "max-content"
     | #minContent => "min-content"
     }
@@ -1641,12 +1641,12 @@ module MinWidth = None
 module MaxWidth = None
 
 module Height = {
-  type t = [#auto | #fitContent(Length.t) | #maxContent | #minContent]
+  type t = [#auto | #fitContent | #maxContent | #minContent]
 
   let toString = x =>
     switch x {
     | #auto => "auto"
-    | #fitContent(l) => "fit-content(" ++ Length.toString(l) ++ ")"
+    | #fitContent => "fit-content"
     | #maxContent => "max-content"
     | #minContent => "min-content"
     }

--- a/bs-css/src/Css_AtomicTypes.resi
+++ b/bs-css/src/Css_AtomicTypes.resi
@@ -1109,7 +1109,7 @@ module TextDecorationThickness: {
  https://developer.mozilla.org/docs/Web/CSS/width
  */
 module Width: {
-  type t = [#auto | #fitContent(Length.t) | #maxContent | #minContent]
+  type t = [#auto | #fitContent | #maxContent | #minContent]
 
   let toString: t => string
 }
@@ -1136,7 +1136,7 @@ module MinWidth: {
  https://developer.mozilla.org/docs/Web/CSS/height
  */
 module Height: {
-  type t = [#auto | #fitContent(Length.t) | #maxContent | #minContent]
+  type t = [#auto | #fitContent | #maxContent | #minContent]
 
   let toString: t => string
 }

--- a/bs-css/src/Css_AtomicTypes.resi
+++ b/bs-css/src/Css_AtomicTypes.resi
@@ -1109,7 +1109,7 @@ module TextDecorationThickness: {
  https://developer.mozilla.org/docs/Web/CSS/width
  */
 module Width: {
-  type t = [#auto | #fitContent | #maxContent | #minContent]
+  type t = [#auto | #fitContent(Length.t) | #maxContent | #minContent]
 
   let toString: t => string
 }
@@ -1124,10 +1124,19 @@ module MaxWidth: {
 }
 
 /**
+ https://developer.mozilla.org/docs/Web/CSS/max-width
+ */
+module MinWidth: {
+  type t = [#none]
+
+  let toString: t => string
+}
+
+/**
  https://developer.mozilla.org/docs/Web/CSS/height
  */
 module Height: {
-  type t = [#auto]
+  type t = [#auto | #fitContent(Length.t) | #maxContent | #minContent]
 
   let toString: t => string
 }
@@ -1136,6 +1145,15 @@ module Height: {
  https://developer.mozilla.org/docs/Web/CSS/max-height
  */
 module MaxHeight: {
+  type t = [#none]
+
+  let toString: t => string
+}
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/min-height
+ */
+module MinHeight: {
   type t = [#none]
 
   let toString: t => string

--- a/bs-css/src/Css_Js_Core.res
+++ b/bs-css/src/Css_Js_Core.res
@@ -747,6 +747,7 @@ let marginBottom = x => D("marginBottom", marginToString(x))
 let maxHeight = x => D(
   "maxHeight",
   switch x {
+  | #...Height.t as mh => Height.toString(mh)
   | #...MaxHeight.t as mh => MaxHeight.toString(mh)
   | #...Percentage.t as p => Percentage.toString(p)
   | #...Length.t as l => Length.toString(l)
@@ -758,6 +759,7 @@ let maxHeight = x => D(
 let maxWidth = x => D(
   "maxWidth",
   switch x {
+  | #...Width.t as mw => Width.toString(mw)
   | #...MaxWidth.t as mw => MaxWidth.toString(mw)
   | #...Percentage.t as p => Percentage.toString(p)
   | #...Length.t as l => Length.toString(l)
@@ -770,6 +772,7 @@ let minHeight = x => D(
   "minHeight",
   switch x {
   | #...Height.t as h => Height.toString(h)
+  | #...MinHeight.t as mh => MinHeight.toString(mh)
   | #...Percentage.t as p => Percentage.toString(p)
   | #...Length.t as l => Length.toString(l)
   | #...Var.t as va => Var.toString(va)
@@ -781,6 +784,7 @@ let minWidth = x => D(
   "minWidth",
   switch x {
   | #...Width.t as w => Width.toString(w)
+  | #...MinWidth.t as w => MinWidth.toString(w)
   | #...Percentage.t as p => Percentage.toString(p)
   | #...Length.t as l => Length.toString(l)
   | #...Var.t as va => Var.toString(va)

--- a/bs-css/src/Css_Js_Core.resi
+++ b/bs-css/src/Css_Js_Core.resi
@@ -810,6 +810,7 @@ let marginBottom: [< Types.Length.t | Types.Margin.t | Types.Var.t | Types.Casca
  It prevents the used value of the height property from becoming larger than the value specified for max-height.
  */
 let maxHeight: [<
+  | Types.Height.t
   | Types.MaxHeight.t
   | Types.Percentage.t
   | Types.Length.t
@@ -822,6 +823,7 @@ let maxHeight: [<
  It prevents the used value of the width property from becoming larger than the value specified by max-width.
  */
 let maxWidth: [<
+  | Types.Width.t
   | Types.MaxWidth.t
   | Types.Percentage.t
   | Types.Length.t
@@ -835,6 +837,7 @@ let maxWidth: [<
  */
 let minHeight: [<
   | Types.Height.t
+  | Types.MinHeight.t
   | Types.Percentage.t
   | Types.Length.t
   | Types.Var.t
@@ -847,6 +850,7 @@ let minHeight: [<
  */
 let minWidth: [<
   | Types.Width.t
+  | Types.MinWidth.t
   | Types.Percentage.t
   | Types.Length.t
   | Types.Var.t

--- a/bs-css/src/Css_Legacy_Core.res
+++ b/bs-css/src/Css_Legacy_Core.res
@@ -743,6 +743,7 @@ let marginBottom = x => D("marginBottom", marginToString(x))
 let maxHeight = x => D(
   "maxHeight",
   switch x {
+  | #...Height.t as mh => Height.toString(mh)
   | #...MaxHeight.t as mh => MaxHeight.toString(mh)
   | #...Percentage.t as p => Percentage.toString(p)
   | #...Length.t as l => Length.toString(l)
@@ -754,6 +755,7 @@ let maxHeight = x => D(
 let maxWidth = x => D(
   "maxWidth",
   switch x {
+  | #...Width.t as mw => Width.toString(mw)
   | #...MaxWidth.t as mw => MaxWidth.toString(mw)
   | #...Percentage.t as p => Percentage.toString(p)
   | #...Length.t as l => Length.toString(l)
@@ -766,6 +768,7 @@ let minHeight = x => D(
   "minHeight",
   switch x {
   | #...Height.t as h => Height.toString(h)
+  | #...MinHeight.t as h => MinHeight.toString(h)
   | #...Percentage.t as p => Percentage.toString(p)
   | #...Length.t as l => Length.toString(l)
   | #...Var.t as va => Var.toString(va)
@@ -777,6 +780,7 @@ let minWidth = x => D(
   "minWidth",
   switch x {
   | #...Width.t as w => Width.toString(w)
+  | #...MinWidth.t as w => MinWidth.toString(w)
   | #...Percentage.t as p => Percentage.toString(p)
   | #...Length.t as l => Length.toString(l)
   | #...Var.t as va => Var.toString(va)

--- a/dev-server-dom/src/Comp.res
+++ b/dev-server-dom/src/Comp.res
@@ -11,7 +11,7 @@ module Section = {
     )
 
     let section = style(. [
-      selector(
+      selector(.
         "& > h1",
         [fontFamily(#custom(arialNarrow)), fontWeight(#num(300)), marginTop(#zero)],
       ),
@@ -47,7 +47,10 @@ let redBox = [
 module RedBox = {
   @react.component
   let make = (~rules=?, ~children=?) =>
-    <div style={style(. rules->Belt.Option.mapWithDefaultU(redBox, (. r) => redBox->Belt.Array.concat(r)))}>
+    <div
+      style={style(.
+        rules->Belt.Option.mapWithDefaultU(redBox, (. r) => redBox->Belt.Array.concat(r)),
+      )}>
       {switch children {
       | None => React.null
       | Some(c) => c

--- a/dev-server-dom/src/Demo.res
+++ b/dev-server-dom/src/Demo.res
@@ -12,8 +12,8 @@ let miniBox = [border(2->px, solid, black), width(15->px), height(15->px), margi
 let mergedStyles = merge(. [
   style(. [padding(0->px), fontSize(1->px)]),
   style(. [padding(20->px), fontSize(24->px), color(blue)]),
-  style(. [media("(maxWidth: 768px)", [padding(10->px)])]),
-  style(. [media("(maxWidth: 768px)", [fontSize(16->px), color(red)])]),
+  style(. [media(. "(maxWidth: 768px)", [padding(10->px)])]),
+  style(. [media(. "(maxWidth: 768px)", [fontSize(16->px), color(red)])]),
 ])
 
 let differentHeightLengths =
@@ -356,7 +356,7 @@ let make = () =>
           flexDirection(column),
           flexGrow(1.),
           alignItems(stretch),
-          selector("& > *", [marginBottom(10->px), width(100.->pct)]),
+          selector(. "& > *", [marginBottom(10->px), width(100.->pct)]),
         ])}>
         <div
           style={style(. [
@@ -625,6 +625,8 @@ let make = () =>
           wordBreak(breakAll),
           wordSpacing(20->px),
           wordWrap(breakWord),
+          width(#maxContent),
+          maxWidth(#maxContent),
         ])}>
         {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."->React.string}
       </p>

--- a/dev-server-emotion/src/Comp.res
+++ b/dev-server-emotion/src/Comp.res
@@ -11,7 +11,7 @@ module Section = {
     )
 
     let section = style(. [
-      selector("& > h1", [fontFamily(#custom(arialNarrow)), marginTop(zero)]),
+      selector(. "& > h1", [fontFamily(#custom(arialNarrow)), marginTop(zero)]),
       position(relative),
       background(hex("f5f5f5")),
       margin(20->px),
@@ -33,7 +33,6 @@ module Section = {
     </section>
 }
 
-
 let redBox = [
   background(red),
   borderBottom(5->px, solid, black),
@@ -46,7 +45,9 @@ module RedBox = {
   @react.component
   let make = (~rules=?, ~children=?) =>
     <div
-     className={style(. rules->Belt.Option.mapWithDefaultU(redBox, (. r) => redBox->Belt.Array.concat(r)))}>
+      className={style(.
+        rules->Belt.Option.mapWithDefaultU(redBox, (. r) => redBox->Belt.Array.concat(r)),
+      )}>
       {switch children {
       | None => React.null
       | Some(c) => c

--- a/dev-server-emotion/src/Demo.res
+++ b/dev-server-emotion/src/Demo.res
@@ -23,8 +23,8 @@ let miniBox = [border(2->px, solid, black), width(15->px), height(15->px), margi
 let mergedStyles = merge(. [
   style(. [padding(0->px), fontSize(1->px)]),
   style(. [padding(20->px), fontSize(24->px), color(blue)]),
-  style(. [media("(max-width: 768px)", [padding(10->px)])]),
-  style(. [media("(max-width: 768px)", [fontSize(16->px), color(red)])]),
+  style(. [media(. "(max-width: 768px)", [padding(10->px)])]),
+  style(. [media(. "(max-width: 768px)", [fontSize(16->px), color(red)])]),
 ])
 
 let differentHeightLengths =
@@ -370,7 +370,7 @@ let make = () =>
           flexDirection(column),
           flexGrow(1.),
           alignItems(stretch),
-          selector("& > *", [marginBottom(10->px), width(pct(100.))]),
+          selector(. "& > *", [marginBottom(10->px), width(pct(100.))]),
         ])}>
         <div
           className={style(. [

--- a/dev-server-fela/src/Demo.res
+++ b/dev-server-fela/src/Demo.res
@@ -27,8 +27,8 @@ let miniBox = style(. [border(2->px, solid, black), width(15->px), height(15->px
 let mergedStyles = merge(. [
   style(. [padding(0->px), fontSize(1->px)]),
   style(. [padding(20->px), fontSize(24->px), color(blue)]),
-  style(. [media("(max-width: 768px)", [padding(10->px)])]),
-  style(. [media("(max-width: 768px)", [fontSize(16->px), color(red)])]),
+  style(. [media(. "(max-width: 768px)", [padding(10->px)])]),
+  style(. [media(. "(max-width: 768px)", [fontSize(16->px), color(red)])]),
 ])
 
 let differentHeightLengths = css =>
@@ -427,7 +427,7 @@ let make = () => {
             flexDirection(column),
             flexGrow(1.),
             alignItems(stretch),
-            selector("& > *", [marginBottom(10->px), width(100.->pct)]),
+            selector(. "& > *", [marginBottom(10->px), width(100.->pct)]),
           ]),
         )}>
         <div

--- a/dev-server-fela/src/Section.res
+++ b/dev-server-fela/src/Section.res
@@ -10,7 +10,10 @@ module Styles = {
   )
 
   let section = style(. [
-    selector("& > h1", [fontFamily(#custom(arialNarrow)), fontWeight(#num(300)), marginTop(#zero)]),
+    selector(.
+      "& > h1",
+      [fontFamily(#custom(arialNarrow)), fontWeight(#num(300)), marginTop(#zero)],
+    ),
     position(#relative),
     background(hex("f5f5f5")),
     margin(px(20)),


### PR DESCRIPTION
- Fixed fit-content
- Added maxWidth/minWidth support for MaxWidth and MinWidth constructors
- Added maxHeight/minHeight for MaxHeight and MinHeight constructors
- Fixed build for dev-server-dom/dev-server-fela/dev-server-emotion since they were using the CssJs and lacked uncurried notation