### PR TITLE
Fix missing quotes for content `<string>` values

### DIFF
--- a/bs-css/src/Css_AtomicTypes.res
+++ b/bs-css/src/Css_AtomicTypes.res
@@ -1977,7 +1977,7 @@ module Content = {
     | #noOpenQuote => "no-open-quote"
     | #noCloseQuote => "no-close-quote"
     | #attr(name) => "attr(" ++ name ++ ")"
-    | #text(value) => value
+    | #text(value) => "\"" ++ value ++ "\""
     }
 }
 


### PR DESCRIPTION
- Resolves https://github.com/giraud/bs-css/issues/263, the fix will break the workaround in https://github.com/giraud/bs-css/issues/263#issuecomment-1386915275 though